### PR TITLE
Fix when link_to_remove contain html

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A vanilla JS replacement for (Rails) [Cocoon](https://github.com/nathanvda/cocoo
 Run:
 
 ```
-yarn add @kollegorna/cocoon-vanilla-js
+yarn add @Belibaste/cocoon-vanilla-js
 ```
 
 Import as ES6 module:

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ const removeFieldsHandler = (btn) => {
         nodeToDelete.parentNode.removeChild(nodeToDelete);
       }
       else {
-        const input = btn.previousElementSibling;
+        const input = nodeToDelete.querySelector('input[type=hidden][name*="[_destroy]"');
         if(input && input.matches('input[type=hidden]')) {
           input.value = 1;
         }

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@kollegorna/cocoon-vanilla-js",
+  "name": "@Belibaste/cocoon-vanilla-js",
   "version": "1.0.3",
   "description": "A vanilla JS replacement for (Rails) Cocoon's jQuery script",
   "main": "index.js",
   "engines": {
     "node": "<=9.11.2"
   },
-  "repository": "git+https://github.com/kollegorna/cocoon-vanilla-js.git",
+  "repository": "git+https://github.com/Belibaste/cocoon-vanilla-js.git",
   "author": "Kollegorna",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/kollegorna/cocoon-vanilla-js/issues"
+    "url": "https://github.com/Belibaste/cocoon-vanilla-js/issues"
   },
-  "homepage": "https://github.com/kollegorna/cocoon-vanilla-js#readme",
+  "homepage": "https://github.com/Belibaste/cocoon-vanilla-js#readme",
   "devDependencies": {},
   "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-"js-utils@git+https://8265015e18616ae2d58e38f4fd9ca111b8beaff8:x-oauth-basic@github.com/kollegorna/js-utils.git#6507589":
+"js-utils@git+https://8265015e18616ae2d58e38f4fd9ca111b8beaff8:x-oauth-basic@github.com/Belibaste/js-utils.git#6507589":
   version "1.0.0"
-  resolved "git+https://8265015e18616ae2d58e38f4fd9ca111b8beaff8:x-oauth-basic@github.com/kollegorna/js-utils.git#6507589ae81c91ff2db72d7c4905a3d2d52674f9"
+  resolved "git+https://8265015e18616ae2d58e38f4fd9ca111b8beaff8:x-oauth-basic@github.com/Belibaste/js-utils.git#6507589ae81c91ff2db72d7c4905a3d2d52674f9"


### PR DESCRIPTION
Hello

This is a small fix for the `removeFieldsHandler` when the `link_to_remove_association` is not only a string, but contain some HTML elements, like the close button from Bootstrap.
As I think this repo is the one people find when they look for a replacement of Cocoon JS (as I did), it would help some of us.

PS @kollegorna : I am not used to contribute, so if you have something to tell me about this, or any advice or comment on this PR, you are very welcome :-)