### PR TITLE
Using closest instead of matches on click events

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,10 +107,10 @@ const addFieldsHandler = (btn) => {
 };
 
 document.addEventListener('click', (e) => {
-  if(e.target.matches('.add_fields')) {
+  if(e.target.closest('.add_fields')) {
     e.preventDefault();
     e.stopPropagation();
-    addFieldsHandler(e.target);
+    addFieldsHandler(e.target.closest('.add_fields'));
   }
 });
 
@@ -147,8 +147,8 @@ const removeFieldsHandler = (btn) => {
 
 document.addEventListener('click', (e) => {
   if(
-    e.target.matches('.remove_fields.dynamic') ||
-    e.target.matches('.remove_fields.existing')
+    e.target.closest('.remove_fields.dynamic') ||
+    e.target.closest('.remove_fields.existing')
   ) {
     e.preventDefault();
     e.stopPropagation();


### PR DESCRIPTION
I was testing this out yesterday to get cocoon and webpacker to work. Ran into issues because I have buttons which have icons or images within the cocoon buttons which is normally fine, since the parent element is the normal clickable element.

However when integrating in cocoon-vanilla-js because it is using matches to detect "does this exact target have the right class" it fails. I fixed it in my vendored copy with the below fix but figured I'd upstream it.